### PR TITLE
Enable AWS Lambda Code Signing and Update Runtime to Supported Version

### DIFF
--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -40,7 +40,7 @@ jobs:
           output_file_path: console,results.sarif
         
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         
         # Results are generated only on a success or failure
         # this is required since GitHub by default won't run the next step

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -104,7 +104,6 @@ jobs:
       run: |
         terraform plan -no-color -input=false \
         -out=TFplan.JSON
-      continue-on-error: true
 
     # Generate an Infracost diff and save it to a JSON file.
     - name: Generate Infracost diff

--- a/lambda.tf
+++ b/lambda.tf
@@ -11,7 +11,7 @@ resource "aws_lambda_function" "lambda_run" {
   function_name    = var.name
   role             = aws_iam_role.lambda_role.arn
   handler          = "handler.lambda_handler"
-  runtime          = "python3.8"
+  runtime          = "python3.12"
   kms_key_arn      = aws_kms_key.encryption.arn
   logging_config {
     log_format       = "JSON"

--- a/lambda.tf
+++ b/lambda.tf
@@ -33,9 +33,9 @@ resource "aws_lambda_function" "lambda_run" {
   dead_letter_config {
     target_arn = aws_sqs_queue.dlq.arn
   }
+  code_signing_config_arn        = aws_lambda_code_signing_config.configuration.arn
   reserved_concurrent_executions = 5
   #checkov:skip=CKV_AWS_50: Not applicable in this use case: X-Ray tracing is enabled for Lambda
-  #checkov:skip=CKV_AWS_272: Not applicable in this use case: Ensure AWS Lambda function is configured to validate code-signing
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule
 resource "aws_cloudwatch_event_rule" "lambda_trigger" {

--- a/lambda_signer.tf
+++ b/lambda_signer.tf
@@ -1,7 +1,7 @@
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/signer_signing_profile
 resource "aws_signer_signing_profile" "lambda_signing_profile" {
   platform_id = "AWSLambda-SHA384-ECDSA"
-  name        = "${var.name}-lambda-signing-profile"
+  name        = "${replace(var.name, "-", "_")}_lambda_signing_profile"
 }
 #https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_code_signing_config
 resource "aws_lambda_code_signing_config" "configuration" {

--- a/lambda_signer.tf
+++ b/lambda_signer.tf
@@ -1,0 +1,15 @@
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/signer_signing_profile
+resource "aws_signer_signing_profile" "lambda_signing_profile" {
+  platform_id = "AWSLambda-SHA384-ECDSA"
+  name        = "${var.name}-lambda-signing-profile"
+}
+#https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_code_signing_config
+resource "aws_lambda_code_signing_config" "configuration" {
+  allowed_publishers {
+    signing_profile_version_arns = [aws_signer_signing_profile.lambda_signing_profile.arn]
+  }
+
+  policies {
+    untrusted_artifact_on_deployment = "Enforce"
+  }
+}


### PR DESCRIPTION
This pull request introduces the following improvements to our AWS Lambda deployment process:

Enforces code signing for Lambda functions:
- Adds an AWS Signer signing profile and Lambda code signing configuration via Terraform. Closes #25 
- Updates the Lambda function resource to require code packages signed with the approved signing profile.

Updates Lambda runtime to a supported version:
- Changes the runtime from the deprecated python3.8 to the latest supported Python version (python3.12).

Ensures compliance with AWS and security best practices:
- Addresses Checkov policies, including CKV_AWS_363 (runtime deprecation) and CKV_AWS_272 (code signing enforcement).
- Refactors resource names to comply with AWS naming requirements.

Impact:
- Only trusted, signed code packages can be deployed to Lambda.
- Lambda functions remain secure and supported by AWS.
- Improves compliance with internal and external security standards.